### PR TITLE
fix: fix the max length of a commit

### DIFF
--- a/git/hooks/commit-msg
+++ b/git/hooks/commit-msg
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-pattern="^(feat|fix|perf|docs|style|refactor|test|build|ci|chore)(\(\w+\))?: .{1,50}(\n\n.*)?(\n\n.*)?$"
+pattern="^(feat|fix|perf|docs|style|refactor|test|build|ci|chore)(\(\w+\))?: .{1,61}(\n\n.*)?(\n\n.*)?$"
 merge_pattern="^Merge.*"
 revert_pattern="^Revert.*"
 commit_msg_file=$1


### PR DESCRIPTION
This pull request includes a small change to the `git/hooks/commit-msg` file. The change updates the commit message pattern to allow for longer messages, increasing the character limit from 50 to 61.

* [`git/hooks/commit-msg`](diffhunk://#diff-1a6b497eedbf25b3c8dc47622959fc3073edbc0b9fbe5601512d06ba60d70191L3-R3): Updated the commit message pattern to allow for messages up to 61 characters long.