### PR TITLE
Fix/app

### DIFF
--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -26,7 +26,7 @@ module "database" {
 module "blob" {
   source              = "./modules/blob"
   location            = var.location
-  resource_group_name = var.resource_group_name
+  resource_group_name = azurerm_resource_group.example.name
 }
 
 module "app" {
@@ -37,7 +37,7 @@ module "app" {
   database_password         = var.database_password
   database_name             = var.database_name
   database_port             = var.database_port
-  resource_group_name       = var.resource_group_name
+  resource_group_name       = azurerm_resource_group.example.name
   storage_blob_url          = module.blob.url
   virtual_network_subnet_id = azurerm_subnet.app.id
 

--- a/infrastructure/variables.tf
+++ b/infrastructure/variables.tf
@@ -6,8 +6,8 @@ variable "location" {
 
 variable "resource_group_name" {
   type        = string
-  default     = "project_resource_group"
-  description = "Name of the resource group in which all resource are grouped"
+  default     = "project-resource-group"
+  description = "Name of the resource group in which all resource are grouped. Use only alphanumeric and dashes."
 }
 
 variable "subscription_id" {


### PR DESCRIPTION
This pull request includes several changes to the `infrastructure` Terraform files to improve consistency and clarity. The most important changes are updates to resource group references and variable definitions.

Updates to resource group references:

* [`infrastructure/main.tf`](diffhunk://#diff-76227b9cdec833d9f836d2b80e9656934c45632a475e29549a438e4048cd5b79L29-R29): Updated the `resource_group_name` parameter in the `module "blob"` and `module "app"` blocks to use `azurerm_resource_group.example.name` instead of `var.resource_group_name`. [[1]](diffhunk://#diff-76227b9cdec833d9f836d2b80e9656934c45632a475e29549a438e4048cd5b79L29-R29) [[2]](diffhunk://#diff-76227b9cdec833d9f836d2b80e9656934c45632a475e29549a438e4048cd5b79L40-R40)

Updates to variable definitions:

* [`infrastructure/variables.tf`](diffhunk://#diff-dd7fa12731755a70849f6f88bdf4bf005c76dfb7c65ae60703cbb7fc6e4e5295L9-R10): Changed the default value of the `resource_group_name` variable to use dashes instead of underscores and updated the description to specify the use of alphanumeric characters and dashes.